### PR TITLE
improvement :allow ranges to get overridden data in the area chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-zero": "^0.0.9",
     "husky": "^3.0.8",
     "lerna": "^3.16.4",
+    "microbundle": "^0.12.0",
     "parcel-bundler": "^1.12.3",
     "typescript": "^3.6.4"
   },

--- a/packages/react-rough-charts/src/baseTypes.ts
+++ b/packages/react-rough-charts/src/baseTypes.ts
@@ -10,6 +10,7 @@ export interface BaseChartProps<T = any> extends ChartContextArgument<T> {
 }
 export interface BaseChartComponentProps<T = any> {
   data?: T[]
+  overrideData? : T[]
   options?: RoughOptions
 }
 

--- a/packages/react-rough-charts/src/components/AreaSeries.tsx
+++ b/packages/react-rough-charts/src/components/AreaSeries.tsx
@@ -25,7 +25,7 @@ export const AreaSeries = <T extends object>(props: AreaSeriesProps<T>) => { // 
     xScale, yScale, xDataKey, areaDataKeys,
   } = scaleData
   const {
-    dataKey, curve, children, padding,
+    dataKey, curve, children, padding, overrideData
   } = props
   const { generateHandlers } = useTooltipGenerator(props as any)
 
@@ -52,7 +52,9 @@ export const AreaSeries = <T extends object>(props: AreaSeriesProps<T>) => { // 
     y0: number
     y1: number
   }
-  const positions: Position[] = data.map((item: any) => {
+
+  let chartData = overrideData || data;
+  const positions: Position[] = chartData.map((item: any) => {
     const { y0, y1 } = calculateY(item)
     return {
       x: xScale(item[xDataKey]),
@@ -88,13 +90,13 @@ export const AreaSeries = <T extends object>(props: AreaSeriesProps<T>) => { // 
             stroke: 'white',
           },
         }
-        const item = data[index] as T
-        const handlers = generateHandlers(data[index], {
+        const item = chartData[index] as T
+        const handlers = generateHandlers(chartData[index], {
           name: `${item[xDataKey]} ${dataKey}`,
           value: `${item[dataKey]}`,
         })
         if (isFunction(children)) {
-          return processTooltipHandlers(children(data[index] as T, childProps, index), handlers)
+          return processTooltipHandlers(children(chartData[index] as T, childProps, index), handlers)
         }
         return (
           <Circle

--- a/packages/react-rough-charts/src/components/ChartProvider.tsx
+++ b/packages/react-rough-charts/src/components/ChartProvider.tsx
@@ -84,8 +84,7 @@ export const ChartProvider: React.FC<ChartProviderProps> = (props) => {
       }}
     >
       <svg
-        height={height}
-        width={width}
+        viewBox={`0 0 ${width} ${height}`}
         ref={ref}
       >
         <RoughProvider


### PR DESCRIPTION
Needed to create a bell curve, with the - 1 * STD until +1 * STD in a different color then the rest of the graph. null values in the data set didn't work.

![image](https://user-images.githubusercontent.com/7676790/82343759-87a40f00-99f3-11ea-9d1b-7d4e94e0a3a1.png)

maybe you can use parts of this code.
![image](https://user-images.githubusercontent.com/7676790/82344016-d0f45e80-99f3-11ea-8e48-f8b0fe4a06b7.png)



